### PR TITLE
Replace SDK facade with a Dart-idiomatic interface

### DIFF
--- a/lib/api.dart
+++ b/lib/api.dart
@@ -43,12 +43,26 @@ class WinWinKit {
   /// Serializers used to encode/decode request and response bodies.
   final Serializers serializers;
 
+  /// Creates a [WinWinKit] client.
+  ///
+  /// [apiKey] is sent as the `x-api-key` header on every request.
+  ///
+  /// Pass [dio] to share a Dio instance across SDKs or inject custom
+  /// interceptors (auth, logging, retry, test adapters). When [dio] is
+  /// supplied, configure its `baseUrl` yourself — [basePathOverride] is
+  /// ignored in that case, and passing both together trips an assertion
+  /// in debug builds.
   WinWinKit({
     required this.apiKey,
     Dio? dio,
     Serializers? serializers,
     String? basePathOverride,
-  })  : serializers = serializers ?? standardSerializers,
+  })  : assert(
+          dio == null || basePathOverride == null,
+          'basePathOverride is ignored when a custom Dio is supplied; '
+          'configure dio.options.baseUrl directly instead.',
+        ),
+        serializers = serializers ?? standardSerializers,
         dio = dio ??
             Dio(BaseOptions(
               baseUrl: basePathOverride ?? basePath,
@@ -104,7 +118,9 @@ class UserClient {
       xApiKey: _sdk.apiKey,
       userCreateRequest: request,
     );
-    return response.data!.data.user;
+    final body = response.data ??
+        (throw StateError('createOrUpdate: response body was empty.'));
+    return body.data.user;
   }
 
   /// Fetches the user.
@@ -113,7 +129,9 @@ class UserClient {
       appUserId: appUserId,
       xApiKey: _sdk.apiKey,
     );
-    return response.data!.data.user;
+    final body = response.data ??
+        (throw StateError('get: response body was empty for user $appUserId.'));
+    return body.data.user;
   }
 
   /// Registers the mapping between this user and an Apple `originalTransactionId`.
@@ -154,7 +172,11 @@ class UserClient {
       xApiKey: _sdk.apiKey,
       userClaimCodeRequest: request,
     );
-    return response.data!.data;
+    final body = response.data ??
+        (throw StateError(
+          'claimCode: response body was empty for user $appUserId.',
+        ));
+    return body.data;
   }
 
   /// Grants a reward to this user. Requires a secret API key.
@@ -172,7 +194,12 @@ class UserClient {
       xApiKey: _sdk.apiKey,
       userGrantRewardRequest: request,
     );
-    return response.data!.data;
+    final body = response.data ??
+        (throw StateError(
+          'grantReward: response body was empty for user $appUserId '
+          'and reward key $key.',
+        ));
+    return body.data;
   }
 
   /// Withdraws [amount] credits of the reward identified by [key].
@@ -192,6 +219,11 @@ class UserClient {
       xApiKey: _sdk.apiKey,
       userWithdrawCreditsRequest: request,
     );
-    return response.data!.data;
+    final body = response.data ??
+        (throw StateError(
+          'withdrawCredits: response body was empty for user $appUserId '
+          'and reward key $key.',
+        ));
+    return body.data;
   }
 }

--- a/lib/api.dart
+++ b/lib/api.dart
@@ -1,83 +1,197 @@
-import 'package:dio/dio.dart';
+//
+// Hand-maintained public facade. Listed in .openapi-generator-ignore so
+// re-running the generator does not clobber it.
+//
+
+import 'package:built_value/json_object.dart';
 import 'package:built_value/serializer.dart';
+import 'package:dio/dio.dart';
+
 import 'package:WinWinKit/./serializers.dart';
-import 'package:WinWinKit/./auth/api_key_auth.dart';
-import 'package:WinWinKit/./auth/basic_auth.dart';
-import 'package:WinWinKit/./auth/bearer_auth.dart';
-import 'package:WinWinKit/./auth/oauth.dart';
 import 'package:WinWinKit/./api/claim_actions_api.dart';
 import 'package:WinWinKit/./api/rewards_actions_api.dart';
 import 'package:WinWinKit/./api/users_api.dart';
+import 'package:WinWinKit/./model/user.dart';
+import 'package:WinWinKit/./model/user_claim_code_request.dart';
+import 'package:WinWinKit/./model/user_claim_code_response_data.dart';
+import 'package:WinWinKit/./model/user_create_request.dart';
+import 'package:WinWinKit/./model/user_grant_reward_request.dart';
+import 'package:WinWinKit/./model/user_grant_reward_response_data.dart';
+import 'package:WinWinKit/./model/user_register_app_store_transaction_request.dart';
+import 'package:WinWinKit/./model/user_register_google_play_transaction_request.dart';
+import 'package:WinWinKit/./model/user_withdraw_credits_request.dart';
+import 'package:WinWinKit/./model/user_withdraw_credits_response_data.dart';
 
+/// Entry point for the WinWinKit Dart SDK.
+///
+/// ```dart
+/// final sdk = WinWinKit(apiKey: 'wwk_live_...');
+/// final user = sdk.user('user_9f2c4e');
+/// await user.registerAppStoreTransaction(
+///   originalTransactionId: '2000000912345678',
+/// );
+/// ```
 class WinWinKit {
   static const String basePath = r'https://api.winwinkit.com';
 
+  /// API key sent as the `x-api-key` header on every request.
+  final String apiKey;
+
+  /// Underlying Dio client. Exposed for custom interceptors / error handling.
   final Dio dio;
+
+  /// Serializers used to encode/decode request and response bodies.
   final Serializers serializers;
 
   WinWinKit({
+    required this.apiKey,
     Dio? dio,
     Serializers? serializers,
     String? basePathOverride,
-    List<Interceptor>? interceptors,
-  })  : this.serializers = serializers ?? standardSerializers,
-        this.dio = dio ??
+  })  : serializers = serializers ?? standardSerializers,
+        dio = dio ??
             Dio(BaseOptions(
               baseUrl: basePathOverride ?? basePath,
               connectTimeout: const Duration(milliseconds: 5000),
               receiveTimeout: const Duration(milliseconds: 3000),
-            )) {
-    if (interceptors == null) {
-      this.dio.interceptors.addAll([
-        OAuthInterceptor(),
-        BasicAuthInterceptor(),
-        BearerAuthInterceptor(),
-        ApiKeyAuthInterceptor(),
-      ]);
-    } else {
-      this.dio.interceptors.addAll(interceptors);
-    }
+            ));
+
+  late final UsersApi _users = UsersApi(dio, this.serializers);
+  late final ClaimActionsApi _claimActions = ClaimActionsApi(dio, this.serializers);
+  late final RewardsActionsApi _rewardsActions = RewardsActionsApi(dio, this.serializers);
+
+  /// Scoped client for operations on a specific user.
+  UserClient user(String appUserId) => UserClient._(this, appUserId);
+
+  /// Escape hatch: the raw generated [UsersApi] for anything the facade
+  /// does not wrap (cancel tokens, custom headers, progress callbacks).
+  UsersApi get rawUsers => _users;
+
+  /// Escape hatch: the raw generated [ClaimActionsApi].
+  ClaimActionsApi get rawClaimActions => _claimActions;
+
+  /// Escape hatch: the raw generated [RewardsActionsApi].
+  RewardsActionsApi get rawRewardsActions => _rewardsActions;
+}
+
+/// Operations scoped to a single user, identified by [appUserId].
+class UserClient {
+  final WinWinKit _sdk;
+
+  /// The app user id this client acts on.
+  final String appUserId;
+
+  UserClient._(this._sdk, this.appUserId);
+
+  /// Creates the user if missing, or updates the existing one.
+  ///
+  /// Returns the updated [User].
+  Future<User> createOrUpdate({
+    bool? isTrial,
+    bool? isPremium,
+    DateTime? firstSeenAt,
+    Map<String, dynamic>? metadata,
+    String? stripeCustomerId,
+  }) async {
+    final request = UserCreateRequest((b) => b
+      ..appUserId = appUserId
+      ..isTrial = isTrial
+      ..isPremium = isPremium
+      ..firstSeenAt = firstSeenAt
+      ..metadata = metadata == null ? null : JsonObject(metadata)
+      ..stripeCustomerId = stripeCustomerId);
+    final response = await _sdk._users.createOrUpdateUser(
+      xApiKey: _sdk.apiKey,
+      userCreateRequest: request,
+    );
+    return response.data!.data.user;
   }
 
-  void setOAuthToken(String name, String token) {
-    if (this.dio.interceptors.any((i) => i is OAuthInterceptor)) {
-      (this.dio.interceptors.firstWhere((i) => i is OAuthInterceptor) as OAuthInterceptor).tokens[name] = token;
-    }
+  /// Fetches the user.
+  Future<User> get() async {
+    final response = await _sdk._users.getUser(
+      appUserId: appUserId,
+      xApiKey: _sdk.apiKey,
+    );
+    return response.data!.data.user;
   }
 
-  void setBearerAuth(String name, String token) {
-    if (this.dio.interceptors.any((i) => i is BearerAuthInterceptor)) {
-      (this.dio.interceptors.firstWhere((i) => i is BearerAuthInterceptor) as BearerAuthInterceptor).tokens[name] = token;
-    }
+  /// Registers the mapping between this user and an Apple `originalTransactionId`.
+  Future<void> registerAppStoreTransaction({
+    required String originalTransactionId,
+    String? appAccountToken,
+  }) async {
+    final request = UserRegisterAppStoreTransactionRequest((b) => b
+      ..originalTransactionId = originalTransactionId
+      ..appAccountToken = appAccountToken);
+    await _sdk._users.registerAppStoreTransaction(
+      appUserId: appUserId,
+      xApiKey: _sdk.apiKey,
+      userRegisterAppStoreTransactionRequest: request,
+    );
   }
 
-  void setBasicAuth(String name, String username, String password) {
-    if (this.dio.interceptors.any((i) => i is BasicAuthInterceptor)) {
-      (this.dio.interceptors.firstWhere((i) => i is BasicAuthInterceptor) as BasicAuthInterceptor).authInfo[name] = BasicAuthInfo(username, password);
-    }
+  /// Registers the mapping between this user and a Google Play `purchaseToken`.
+  Future<void> registerGooglePlayTransaction({
+    required String purchaseToken,
+    String? obfuscatedExternalAccountId,
+  }) async {
+    final request = UserRegisterGooglePlayTransactionRequest((b) => b
+      ..purchaseToken = purchaseToken
+      ..obfuscatedExternalAccountId = obfuscatedExternalAccountId);
+    await _sdk._users.registerGooglePlayTransaction(
+      appUserId: appUserId,
+      xApiKey: _sdk.apiKey,
+      userRegisterGooglePlayTransactionRequest: request,
+    );
   }
 
-  void setApiKey(String name, String apiKey) {
-    if (this.dio.interceptors.any((i) => i is ApiKeyAuthInterceptor)) {
-      (this.dio.interceptors.firstWhere((element) => element is ApiKeyAuthInterceptor) as ApiKeyAuthInterceptor).apiKeys[name] = apiKey;
-    }
+  /// Claims an affiliate, promo, or referral [code] for this user.
+  Future<UserClaimCodeResponseData> claimCode(String code) async {
+    final request = UserClaimCodeRequest((b) => b..code = code);
+    final response = await _sdk._claimActions.claimCode(
+      appUserId: appUserId,
+      xApiKey: _sdk.apiKey,
+      userClaimCodeRequest: request,
+    );
+    return response.data!.data;
   }
 
-  /// Get ClaimActionsApi instance, base route and serializer can be overridden by a given but be careful,
-  /// by doing that all interceptors will not be executed
-  ClaimActionsApi getClaimActionsApi() {
-    return ClaimActionsApi(dio, serializers);
+  /// Grants a reward to this user. Requires a secret API key.
+  ///
+  /// [key] identifies the reward. [operationId] makes the grant idempotent.
+  Future<UserGrantRewardResponseData> grantReward({
+    required String key,
+    String? operationId,
+  }) async {
+    final request = UserGrantRewardRequest((b) => b
+      ..key = key
+      ..operationId = operationId);
+    final response = await _sdk._rewardsActions.grantReward(
+      appUserId: appUserId,
+      xApiKey: _sdk.apiKey,
+      userGrantRewardRequest: request,
+    );
+    return response.data!.data;
   }
 
-  /// Get RewardsActionsApi instance, base route and serializer can be overridden by a given but be careful,
-  /// by doing that all interceptors will not be executed
-  RewardsActionsApi getRewardsActionsApi() {
-    return RewardsActionsApi(dio, serializers);
-  }
-
-  /// Get UsersApi instance, base route and serializer can be overridden by a given but be careful,
-  /// by doing that all interceptors will not be executed
-  UsersApi getUsersApi() {
-    return UsersApi(dio, serializers);
+  /// Withdraws [amount] credits of the reward identified by [key].
+  ///
+  /// [operationId] makes the withdrawal idempotent.
+  Future<UserWithdrawCreditsResponseData> withdrawCredits({
+    required String key,
+    required int amount,
+    String? operationId,
+  }) async {
+    final request = UserWithdrawCreditsRequest((b) => b
+      ..key = key
+      ..amount = amount
+      ..operationId = operationId);
+    final response = await _sdk._rewardsActions.withdrawCredits(
+      appUserId: appUserId,
+      xApiKey: _sdk.apiKey,
+      userWithdrawCreditsRequest: request,
+    );
+    return response.data!.data;
   }
 }


### PR DESCRIPTION
## Summary

- Replaces the generator-shaped `WinWinKit` facade with a Dart-native one. `WinWinKit(apiKey: 'wwk_live_…')` drops the `..setApiKey('x-api-key', …)` wire-level cascade.
- Introduces `sdk.user(appUserId)` → `UserClient`, so `appUserId` and `xApiKey` are no longer threaded through every call. Seven scoped methods: `createOrUpdate`, `get`, `claimCode`, `grantReward`, `withdrawCredits`, `registerAppStoreTransaction`, `registerGooglePlayTransaction`.
- Request bodies use flat named params (e.g. `registerAppStoreTransaction(originalTransactionId: …, appAccountToken: …)`) instead of `built_value` builder callbacks. Responses return unwrapped domain types (`User`, `UserClaimCodeResponseData`, …) instead of `Response<UserResponse>` envelopes.
- `sdk.rawUsers`, `sdk.rawClaimActions`, `sdk.rawRewardsActions` getters expose the generated APIs for cancel tokens, custom headers, progress callbacks.
- Breaking change for existing `0.5.x` consumers (package is marked EXPERIMENTAL). Suggested release: minor bump to `0.6.0` after merge.

## Test plan

- [x] `dart analyze` is clean (no new warnings beyond the 20 pre-existing generator ones)
- [ ] `WinWinKit(apiKey: …).user('u').createOrUpdate(isTrial: true)` compiles
- [ ] `sdk.user('u').registerAppStoreTransaction(originalTransactionId: '…')` compiles
- [ ] Escape hatch: `sdk.rawUsers.getUser(appUserId: 'u', xApiKey: sdk.apiKey, cancelToken: …)` compiles
- [x] Next `./openapi.generate` run does not overwrite `lib/api.dart` (already in `.openapi-generator-ignore` from #3)
- [ ] Prefer a merge commit when landing (not squash), per repo convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)